### PR TITLE
postgres port configurable

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -11,6 +11,7 @@ const config = {
   'password': process.env.IWS_POSTGRES_IWS_PASSWORD,
   'database': process.env.IWS_POSTGRES_IWS_DATABASE,
   'host': process.env.IWS_POSTGRES_IWS_HOST || '127.0.0.1',
+  'port': process.env.IWS_POSTGRES_HOST_PORT || 5332,
   'dialect': 'postgres'
 }
 


### PR DESCRIPTION
Postgres port is now configurable to allow Docker and local Postgresql installations to work side by side.